### PR TITLE
vmm: suspend: refine suspend logic

### DIFF
--- a/include/lib/mp_init.h
+++ b/include/lib/mp_init.h
@@ -25,6 +25,9 @@ void wakeup_aps(uint32_t sipi_page);
 /* Get active cpu number */
 uint32_t get_active_cpu_num(void);
 
+/* Get start-up code page size */
+uint32_t get_startup_code_size(void);
+
 uint32_t launch_aps(uint32_t sipi_page, uint8_t expected_cpu_num, uint64_t c_entry);
 
 #endif /* _MP_INIT_H_ */

--- a/lib/mp_init/mp_init.c
+++ b/lib/mp_init/mp_init.c
@@ -84,6 +84,11 @@ uint32_t get_active_cpu_num(void)
 	return g_startup_data.cpu_num;
 }
 
+uint32_t get_startup_code_size(void)
+{
+	return sizeof(real_mode_code);
+}
+
 void setup_sipi_page(uint64_t sipi_page, boolean_t need_wakeup_bsp, uint64_t c_entry)
 {
 	uint8_t *code_to_patch = (uint8_t *)sipi_page;


### PR DESCRIPTION
Do not reserve a 4K page for suspend feature support.
Save SIPI page memory before suspend and restore the SIPI
page memory after resume.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>