### PR TITLE
loader: remove ULL suffix from assembly file

### DIFF
--- a/loader/stage0/abl/stage0_entry.S
+++ b/loader/stage0/abl/stage0_entry.S
@@ -224,9 +224,9 @@ bspstack:
 
 .balign 8
 gdt_x64:
-	.quad 	0x0000000000000000ULL	/* NULL descriptor */
-	.quad 	0x00af9b000000ffffULL	/* 0x08 __BOOT_CS */
-	.quad 	0x00cf93000000ffffULL	/* 0x10 __BOOT_DS */
+	.quad 	0x0000000000000000	/* NULL descriptor */
+	.quad 	0x00af9b000000ffff	/* 0x08 __BOOT_CS */
+	.quad 	0x00cf93000000ffff	/* 0x10 __BOOT_DS */
 gdt_x64_end:
 
 gdtr_x64:

--- a/loader/stage0/abl_cl/stage0_entry.S
+++ b/loader/stage0/abl_cl/stage0_entry.S
@@ -224,9 +224,9 @@ bspstack:
 
 .balign 8
 gdt_x64:
-	.quad 	0x0000000000000000ULL	/* NULL descriptor */
-	.quad 	0x00af9b000000ffffULL	/* 0x08 __BOOT_CS */
-	.quad 	0x00cf93000000ffffULL	/* 0x10 __BOOT_DS */
+	.quad 	0x0000000000000000	/* NULL descriptor */
+	.quad 	0x00af9b000000ffff	/* 0x08 __BOOT_CS */
+	.quad 	0x00cf93000000ffff	/* 0x10 __BOOT_DS */
 gdt_x64_end:
 
 gdtr_x64:

--- a/loader/stage0/grub-qemu/stage0_entry.S
+++ b/loader/stage0/grub-qemu/stage0_entry.S
@@ -183,10 +183,10 @@ bspstack:
 
 .balign 8
 gdt_x64:
-	.quad   0x0000000000000000ULL  /* NULL descriptor */
-	.quad   0x0000000000000000ULL  /* reserved for linux boot protocal */
-	.quad   0x00af9b000000ffffULL  /* 0x10 __BOOT_CS */
-	.quad   0x00cf93000000ffffULL  /* 0x18 __BOOT_DS */
+	.quad   0x0000000000000000  /* NULL descriptor */
+	.quad   0x0000000000000000  /* reserved for linux boot protocal */
+	.quad   0x00af9b000000ffff  /* 0x10 __BOOT_CS */
+	.quad   0x00cf93000000ffff  /* 0x18 __BOOT_DS */
 gdt_x64_end:
 
 gdtr_x64:

--- a/loader/stage0/sbl/stage0_entry.S
+++ b/loader/stage0/sbl/stage0_entry.S
@@ -224,9 +224,9 @@ bspstack:
 
 .balign 8
 gdt_x64:
-	.quad 	0x0000000000000000ULL	/* NULL descriptor */
-	.quad 	0x00af9b000000ffffULL	/* 0x08 __BOOT_CS */
-	.quad 	0x00cf93000000ffffULL	/* 0x10 __BOOT_DS */
+	.quad 	0x0000000000000000	/* NULL descriptor */
+	.quad 	0x00af9b000000ffff	/* 0x08 __BOOT_CS */
+	.quad 	0x00cf93000000ffff	/* 0x10 __BOOT_DS */
 gdt_x64_end:
 
 gdtr_x64:


### PR DESCRIPTION
Some old version of GCC/GNU AS does not support "ULL"
suffix in assemble file.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>