### PR TITLE
Minor fix civ

### DIFF
--- a/lib/print/serial.c
+++ b/lib/print/serial.c
@@ -43,25 +43,28 @@ serial_device_t g_ser_dev = {
 	.base = -1ULL
 };
 
-static inline uint8_t serial_mmio_get(uint64_t base_addr, uint32_t reg)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+static uint8_t serial_mmio_get(uint64_t base_addr, uint32_t reg)
 {
 	return *(volatile uint8_t *)(base_addr + (uint64_t)reg * 4);
 }
 
-static inline void serial_mmio_set(uint64_t base_addr, uint32_t reg, uint8_t val)
+static void serial_mmio_set(uint64_t base_addr, uint32_t reg, uint8_t val)
 {
 	*(volatile uint8_t *)(base_addr + (uint64_t)reg * 4) = val;
 }
 
-static inline uint8_t serial_io_get(uint64_t base_addr, uint32_t reg)
+static uint8_t serial_io_get(uint64_t base_addr, uint32_t reg)
 {
 	return asm_in8((uint16_t)base_addr + (uint16_t)reg);
 }
 
-static inline void serial_io_set(uint64_t base_addr, uint32_t reg, uint8_t val)
+static void serial_io_set(uint64_t base_addr, uint32_t reg, uint8_t val)
 {
 	asm_out8((uint16_t)base_addr + (uint16_t)reg, val);
 }
+#pragma GCC diagnostic pop
 
 static void serial_8250_init(uint64_t serial_base)
 {

--- a/vmm/modules/l1tf/l1tf.c
+++ b/vmm/modules/l1tf/l1tf.c
@@ -258,7 +258,7 @@ static void register_mitigation_event(void)
 			}
 		}
 	} else {
-		print_warn("IA32_ARCH_CAPABILITIES is not supported!");
+		print_warn("IA32_ARCH_CAPABILITIES is not supported!\n");
 	}
 }
 

--- a/vmm/modules/perf_ctrl_isolation/perf_ctrl_isolation.c
+++ b/vmm/modules/perf_ctrl_isolation/perf_ctrl_isolation.c
@@ -65,12 +65,12 @@ static void perf_ctrl_isolation_gcpu_init(guest_cpu_handle_t gcpu, UNUSED void *
 void msr_perf_ctrl_isolation_init(void)
 {
 	if (!(get_entryctl_cap(NULL) & ENTRY_LOAD_IA32_PERF_CTRL)) {
-		print_warn("ENTRY_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!");
+		print_warn("ENTRY_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!\n");
 		return;
 	}
 
 	if (!(get_exitctl_cap(NULL) & EXIT_LOAD_IA32_PERF_CTRL)) {
-		print_warn("EXIT_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!");
+		print_warn("EXIT_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!\n");
 		return;
 	}
 

--- a/vmm/utils/lock.c
+++ b/vmm/utils/lock.c
@@ -13,7 +13,7 @@
 #include "lib/print.h"
 
 #define WRITELOCK_MASK  0x80000000
-#define DEADLOCK_CYCLE 1200000
+#define DEADLOCK_CYCLE 12000000
 
 #if LOG_LEVEL >= LEVEL_PANIC
 static boolean_t printed = FALSE;


### PR DESCRIPTION
vmm: add line break for some warning logs
vmm: lock: enlarge DEADLOCK_CYCLE
lib: print: fix compiling issue of unused function

Signed-off-by: Qi Yadong yadong.qi@intel.com