### PR TITLE
vmm: remove the workaround for KVM when reset gcpu state

### DIFF
--- a/vmm/guest/gcpu_state.c
+++ b/vmm/guest/gcpu_state.c
@@ -16,7 +16,6 @@
 #include "hmm.h"
 #include "vmexit_cr_access.h"
 #include "event.h"
-#include "kvm_workaround.h"
 
 #include "lib/util.h"
 
@@ -278,17 +277,8 @@ void gcpu_set_reset_state(guest_cpu_handle_t gcpu)
 	vmcs_write(vmcs, VMCS_GUEST_SYSENTER_EIP, 0);
 	vmcs_write(vmcs, VMCS_GUEST_PAT, asm_rdmsr(MSR_PAT));
 
-	/*
-	 * Running on KVM: Put guest CPU into the HLT state
-	 * Others:         Put guest CPU into the WAIT-FOR-SIPI state
-	 */
-	if (running_on_kvm()) {
-		vmcs_write(vmcs, VMCS_GUEST_ACTIVITY_STATE,
-				ACTIVITY_STATE_HLT);
-	} else {
-		vmcs_write(vmcs, VMCS_GUEST_ACTIVITY_STATE,
-				ACTIVITY_STATE_WAIT_FOR_SIPI);
-	}
+	vmcs_write(vmcs, VMCS_GUEST_ACTIVITY_STATE,
+			ACTIVITY_STATE_WAIT_FOR_SIPI);
 
 	cr0_guest_write(gcpu, 0x60000010);
 	cr4_guest_write(gcpu, 0);


### PR DESCRIPTION
Remove the workaround for KVM when reset gcpu state.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>