### PR TITLE
vmm: suspend: refine ACPI/FADT parse

### DIFF
--- a/vmm/include/modules/acpi.h
+++ b/vmm/include/modules/acpi.h
@@ -45,6 +45,28 @@ typedef struct {
 	uint32_t	asl_compiler_revision;				/* ASL compiler version */
 } acpi_table_header_t;
 
+/*
+ * Generic Address Structure -- ACPI specification, Chapter 5.2.3.2 Generic Address Structure
+ */
+typedef struct {
+	uint8_t		as_id;			// Address Space ID
+	uint8_t		reg_bit_width;		// Register Bit Width
+	uint8_t		reg_bit_off;		// Register Bit Offset
+	uint8_t		access_size;		// Access Size
+	uint64_t	addr;			// Address
+} PACKED acpi_generic_address_t;
+
+/* Address Space ID enumeration */
+#define ACPI_GAS_ID_MEM      0U    //System Memory Space
+#define ACPI_GAS_ID_IO       1U    //System I/O space
+
+/* Address Space access size enumeration */
+#define ACPI_GAS_AS_UNDEF    0U
+#define ACPI_GAS_AS_BYTE     1U    // 1 byte
+#define ACPI_GAS_AS_WORD     2U    // 2 bytes
+#define ACPI_GAS_AS_DWORD    3U    // 4 bytes
+#define ACPI_GAS_AS_QWORD    4U    // 8 bytes
+
 #ifdef DEBUG
 void acpi_print_header(acpi_table_header_t *table_header);
 #endif

--- a/vmm/modules/suspend/acpi_pm.h
+++ b/vmm/modules/suspend/acpi_pm.h
@@ -9,17 +9,15 @@
 #ifndef _ACPI_PM_H_
 #define _ACPI_PM_H_
 
-#define ACPI_PM1_CNTRL_A        0
-#define ACPI_PM1_CNTRL_B        1
-#define ACPI_PM1_CNTRL_COUNT    2
+#define ACPI_PM1A_CNT    0U
+#define ACPI_PM1B_CNT    1U
+#define ACPI_PM1_CNT_NUM 2U
 
-typedef struct {
-	uint32_t *p_waking_vector;
-	uint16_t port_id[ACPI_PM1_CNTRL_COUNT];
-	uint32_t pad;
-} acpi_fadt_info_t;
+#include "modules/acpi.h"
 
-boolean_t acpi_pm_is_s3(uint16_t port_id ,uint32_t port_size, uint32_t value);
-void acpi_pm_init(acpi_fadt_info_t *p_acpi_fadt_info);
+boolean_t acpi_pm_is_s3(uint64_t addr, uint32_t size, uint32_t value);
+acpi_generic_address_t *get_pm1x_reg(uint32_t id);
+uint32_t *get_waking_vector(void);
+void acpi_pm_init(void);
 
 #endif


### PR DESCRIPTION
According to ACPI Spec Chapter 5.2.9 Fixed ACPI Description Table:
    If X_PM1a_CNT_BLK field contains a non zero value which can be used by the OSPM,
    then PM1a_CNT_BLK must be ignored by the OSPM.

The PM1a/b_CNT block parsing logic is revisited in this patch.
Add assumptions/asserts when parsing PM1 control block:
    1. The control register block type is IO, assert on MMIO/MEM. May need revisit.
    2. X_FW_WAKING_VECTOR is not used since we do not support 32/64 waking entry.
       May need revisit.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>